### PR TITLE
Fix drop shadow to now use android elevations

### DIFF
--- a/App/app/src/main/res/drawable/rounded_corner.xml
+++ b/App/app/src/main/res/drawable/rounded_corner.xml
@@ -1,23 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
 
-<item>
-    <shape android:shape="rectangle">
-        <solid android:color="@color/lightGrey" />
-        <corners android:radius="8dp" />
-    </shape>
-</item>
+    <solid android:color="@color/colourTertiary"/>
 
-<item
-    android:bottom="2dp"
-    android:left="0dp"
-    android:right="0dp"
-    android:top="0dp">
-    <shape android:shape="rectangle">
-        <solid android:color="@color/colourTertiary" />
+    <!--<stroke android:width="2dp"-->
+        <!--android:color="#999999"/>-->
 
-        <corners android:radius="4dp" />
-    </shape>
-</item>
+    <padding android:left="2dp"
+        android:top="2dp"
+        android:right="2dp"
+        android:bottom="2dp"/>
 
-</layer-list>
+    <corners android:bottomRightRadius="8dp"
+        android:bottomLeftRadius="8dp"
+        android:topLeftRadius="8dp"
+        android:topRightRadius="8dp"/>
+
+
+</shape>

--- a/App/app/src/main/res/layout/content_links.xml
+++ b/App/app/src/main/res/layout/content_links.xml
@@ -23,7 +23,8 @@
             android:layout_marginStart="13dp"
             android:layout_marginTop="15dp"
             android:layout_marginBottom="3dp"
-            android:background="@drawable/rounded_corner">
+            android:background="@drawable/rounded_corner"
+            android:elevation="4dp">
 
 
             <RelativeLayout

--- a/App/app/src/main/res/values/colors.xml
+++ b/App/app/src/main/res/values/colors.xml
@@ -7,5 +7,4 @@
     <color name="colourLightGrey">#DFDFDF</color>
     <color name="colourTertiary">#ca2139</color>
     <color name="white">#ffffff</color>
-    <color name="lightGrey">#bababa</color>
 </resources>


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Use Android best practices via elevation
![image](https://user-images.githubusercontent.com/17136826/32695409-d6cc0b1e-c728-11e7-8fd1-194fe6be3ff7.png)

### How is this accomplished?
- removed alternative dropshadow approach using multiple shapes
- added elevation tag to layout

### Checklist

- [x] I have tested the changes in development
- [ ] I have received review from at least one other team member